### PR TITLE
Fix linking opencv libs

### DIFF
--- a/Source/ThirdParty/OpenCV/OpenCV.Build.cs
+++ b/Source/ThirdParty/OpenCV/OpenCV.Build.cs
@@ -18,6 +18,8 @@ public class OpenCV : ModuleRules
         Type = ModuleRules.ModuleType.External;
         PrecompileForTargets = PrecompileTargetsType.Any;
         PublicPreBuildLibraries.Add(Path.Combine(ModuleDirectory, "lib/libopencv_core.dylib"));
+        PublicPreBuildLibraries.Add(Path.Combine(ModuleDirectory, "lib/libopencv_imgcodecs.dylib"));
+        PublicPreBuildLibraries.Add(Path.Combine(ModuleDirectory, "lib/libopencv_imgproc.dylib"));
         PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "include/opencv4"));
 	}
 }

--- a/Source/ThirdParty/OpenCV/OpenCVUtils.h
+++ b/Source/ThirdParty/OpenCV/OpenCVUtils.h
@@ -1,0 +1,13 @@
+// Copyright Epic Games, Inc. All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+namespace OpenCVUtils
+{
+    //Keep track of UE's int64 and uint64 typedefs 
+    //to be able to restore it after including CV headers
+    using UEInt64 = FPlatformTypes::int64;
+    using UEUInt64 = FPlatformTypes::uint64;
+};

--- a/Source/ThirdParty/OpenCV/PostOpenCVHeaders.h
+++ b/Source/ThirdParty/OpenCV/PostOpenCVHeaders.h
@@ -1,0 +1,42 @@
+// Copyright Epic Games, Inc. All Rights Reserved.
+
+#ifdef OPENCV_HEADERS_TYPES_GUARD
+#undef OPENCV_HEADERS_TYPES_GUARD
+#else
+#error Mismatched PreOpenCVHeadersTypes.h detected.
+#endif
+
+// HEADER_UNIT_SKIP - Special include
+
+#include "OpenCVUtils.h"
+
+#if PLATFORM_WINDOWS
+
+__pragma(warning(pop))
+UE_POP_MACRO("check")
+THIRD_PARTY_INCLUDES_END
+
+#elif PLATFORM_LINUX
+
+//Stamp CV's int64 type to use it with their api and restore our definition of int64 after including CV's headers
+namespace OpenCVUtils
+{
+    using cvint64 = int64;
+    using cvuintt64 = uint64;
+}
+
+#undef int64
+#undef uint64
+using int64 = OpenCVUtils::UEInt64;
+using uint64 = OpenCVUtils::UEUInt64;
+
+#pragma warning(pop)
+UE_POP_MACRO("check")
+THIRD_PARTY_INCLUDES_END
+
+#else
+
+UE_POP_MACRO("check")
+THIRD_PARTY_INCLUDES_END
+
+#endif

--- a/Source/ThirdParty/OpenCV/PreOpenCVHeaders.h
+++ b/Source/ThirdParty/OpenCV/PreOpenCVHeaders.h
@@ -1,0 +1,59 @@
+// Copyright Epic Games, Inc. All Rights Reserved.
+
+#ifndef OPENCV_HEADERS_TYPES_GUARD
+#define OPENCV_HEADERS_TYPES_GUARD
+#else
+#error Nesting PostOpenCVHeadersTypes.h is not allowed!
+#endif
+
+#include "OpenCVUtils.h"
+
+#if PLATFORM_WINDOWS
+
+THIRD_PARTY_INCLUDES_START
+UE_PUSH_MACRO("check")
+#undef check
+
+__pragma(warning(push))
+__pragma(warning(disable: 4190))  /* 'identifier1' has C-linkage specified, but returns UDT 'identifier2' which is incompatible with C */
+__pragma(warning(disable: 6297))  /* Arithmetic overflow:  32-bit value is shifted, then cast to 64-bit value.  Results might not be an expected value. */
+__pragma(warning(disable: 6294))  /* Ill-defined for-loop:  initial condition does not satisfy test.  Loop body not executed. */
+__pragma(warning(disable: 6201))  /* Index '<x>' is out of valid index range '<a>' to '<b>' for possibly stack allocated buffer '<variable>'. */
+__pragma(warning(disable: 6269))  /* Possibly incorrect order of operations:  dereference ignored. */
+__pragma(warning(disable: 4263)) /* cv::detail::BlocksCompensator::feed member function does not override any base class virtual member function */
+__pragma(warning(disable: 4264)) /* cv::detail::ExposureCompensator::feed : no override available for virtual member function from base 'cv::detail::ExposureCompensator'; function is hidden */
+
+#elif PLATFORM_LINUX
+
+THIRD_PARTY_INCLUDES_START
+UE_PUSH_MACRO("check")
+#undef check
+
+#pragma warning(push) 
+#pragma warning(disable: 4190)  /* 'identifier1' has C-linkage specified, but returns UDT 'identifier2' which is incompatible with C */ 
+#pragma warning(disable: 6297)  /* Arithmetic overflow:  32-bit value is shifted, then cast to 64-bit value.  Results might not be an expected value. */ 
+#pragma warning(disable: 6294)  /* Ill-defined for-loop:  initial condition does not satisfy test.  Loop body not executed. */ 
+#pragma warning(disable: 6201)  /* Index '<x>' is out of valid index range '<a>' to '<b>' for possibly stack allocated buffer '<variable>'. */ 
+#pragma warning(disable: 6269)  /* Possibly incorrect order of operations:  dereference ignored. */ 
+#pragma warning(disable: 4263) /* cv::detail::BlocksCompensator::feed member function does not override any base class virtual member function */ 
+#pragma warning(disable: 4264) /* cv::detail::ExposureCompensator::feed : no override available for virtual member function from base 'cv::detail::ExposureCompensator'; function is hidden */ 
+
+//Conflicting typedef of int64 and uint64 between OpenCV and UE
+//Trick it by defining int64 to its own type, include CV headers 
+//and put back our own type in it afterwards in PostIncludes
+//Issue has been flagged in opencv github and referenced here 
+//https://github.com/opencv/opencv/issues/7573
+#define int64 cvint64
+#define uint64 cvuint64
+
+#else
+
+// TODO: when adding support for other platforms, this definition may require updating
+THIRD_PARTY_INCLUDES_START
+UE_PUSH_MACRO("check")
+#undef check
+
+#endif
+
+
+

--- a/Source/ThirdParty/OpenCV/download-and-build-opencv.sh
+++ b/Source/ThirdParty/OpenCV/download-and-build-opencv.sh
@@ -27,7 +27,26 @@ else
   cd opencv-${opencv_version}
   mkdir -p build
   cd build
-  cmake ../ -D OPENCV_EXTRA_MODULES_PATH=../../opencv_contrib-${opencv_version}/modules -D CMAKE_INSTALL_PREFIX=../../
+  cmake ../ \
+    -D CMAKE_INSTALL_PREFIX=../../ \
+    -D OPENCV_EXTRA_MODULES_PATH=../../opencv_contrib-${opencv_version}/modules \
+    -D BUILD_EXAMPLES=OFF \
+    -D BUILD_PERF_TESTS=OFF \
+    -D BUILD_TESTS=OFF \
+    -D BUILD_opencv_apps=OFF \
+    -D BUILD_opencv_calib3d=OFF \
+    -D BUILD_opencv_dnn=OFF \
+    -D BUILD_opencv_face=OFF \
+    -D BUILD_opencv_gapi=OFF \
+    -D BUILD_opencv_ml=OFF \
+    -D BUILD_opencv_photo=OFF \
+    -D BUILD_opencv_python2=OFF \
+    -D BUILD_opencv_python3=OFF \
+    -D BUILD_opencv_STEREO=OFF \
+    -D BUILD_opencv_stitching=OFF \
+    -D BUILD_opencv_tracking=OFF \
+    -D WITH_OPENEXR=OFF \
+    -D BUILD_ZLIB=OFF
   cmake --build . --parallel 8
   cmake --install . 
 endif


### PR DESCRIPTION
* **Tickets addressed:** NA
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
In my previous PR, I foolishly forgot to provide the paths to all the opencv libraries Cielim needs. This resulted in linker errors when using the library. The first commit of this PR add pre and post include headers to guard against the duplicate definition of macros in Unreal. The following two commits adjust the opencv library linking.

## Verification
Built and tested by using OpenCV in Cielim.

## Documentation
NA

## Future work
We really need to get our testing framework and Ci process setup. This is happening now and can't come soon enough.
