### PR TITLE
Feature/quantum efficiency

### DIFF
--- a/Source/cielim/Private/RenderingFunctionsLibrary.cpp
+++ b/Source/cielim/Private/RenderingFunctionsLibrary.cpp
@@ -237,3 +237,48 @@ FString URenderingFunctionsLibrary::ApplyDarkCurrentNoise(
 	
 	return ResultFilepath;
 }
+
+FString URenderingFunctionsLibrary::ApplyQE(FString Filepath, float QERed, float QEGreen, float QEBlue)
+{
+	FVector3d QE;
+
+	QE[0] = QERed;
+	QE[1] = QEGreen;
+	QE[2] = QEBlue;
+	
+	//Read Image
+	FString Filepath_Absolute = IFileManager::Get().ConvertToAbsolutePathForExternalAppForRead(*Filepath);
+	std::string Filepath_Absolute_String = TCHAR_TO_UTF8(*Filepath_Absolute);
+	cv::Mat Image = cv::imread(Filepath_Absolute_String);
+	
+	//Init Result Image
+	cv::Mat ResultImage = cv::Mat::zeros(Image.rows, Image.cols, Image.type());
+
+	//Loop Through Every Pixel, Apply QE
+	for(int row=0; row < Image.rows; row++)
+	{
+		for(int col=0; col < Image.cols; col++)
+		{
+			
+			cv::Vec3b NewPixel;
+			
+			for (int ColorChannel = 0; ColorChannel < 3; ColorChannel++)
+			{
+				NewPixel[ColorChannel] = static_cast<uchar>(Image.at<cv::Vec3b>(row, col)[ColorChannel] * QE[ColorChannel]);
+			}
+			
+			ResultImage.at<cv::Vec3b>(row, col) = NewPixel;
+			
+		}
+	}
+	
+	//Save image
+	FString ResultFilepath = FPaths::ProjectDir();
+	ResultFilepath.Append("Result_Images/");
+	ResultFilepath.Append("QE.jpg");
+	
+	std::string ResultFilepath_String = TCHAR_TO_UTF8(*ResultFilepath);
+	cv::imwrite(ResultFilepath_String, ResultImage);
+	
+	return ResultFilepath;
+}

--- a/Source/cielim/Private/RenderingFunctionsLibrary.h
+++ b/Source/cielim/Private/RenderingFunctionsLibrary.h
@@ -36,4 +36,7 @@ class  CIELIM_API URenderingFunctionsLibrary :
 		FVector SpacecraftPosition,
 		FVector SpacecraftDirection
 		);
+
+	UFUNCTION(BlueprintCallable, Category="Rendering Functions")
+	static FString ApplyQE(FString Filepath, float QERed, float QEGreen, float QEBlue);
 };


### PR DESCRIPTION
* **Tickets addressed:** 510
* **Review:** By commit  
* **Merge strategy:** Merge (no squash)  

## Description
This branch implements a basic version of quantum efficiency, which in this case alters the signal of each color channel of an image. In this case a float is specified for each channel and then is multiplied by that channel. 

## Verification
Changes were verified by applying the ApplyQE function on a test image, and observing the intended behavior. In order for the user to verify these changes, one can go into the Lvl_Visualization level, navigate to the Level Blue Print and Adjust the Apply QE function accordingly (with an appropriate file path and RGB values). Then the user can run the scene by selecting the Play drop down menu (signified by the three dots next to the main play button) and selecting "Selected Viewport". The user can then press the "1" button and observe the altered test image.

## Documentation
No Documentation change is needed.

## Future work
Calculation of QE via estimation of spectral reflectance.