### PR TITLE
Hotfix/request image crash fix

### DIFF
--- a/Source/test/test_demo.py
+++ b/Source/test/test_demo.py
@@ -19,7 +19,7 @@ if __name__ == "__main__":
             break
 
         connector.send_frame(frame)
-        image = connector.request_image_for_camera_id(1)
+        [image, center_of_brightness] = connector.request_image_for_camera_id(1)
 
         cv2.imwrite("received_image_" + str(idx) + ".png", image)
 

--- a/Source/test/test_harness.py
+++ b/Source/test/test_harness.py
@@ -42,7 +42,7 @@ class Connector:
 
     def request_image_for_camera_id(self, camera_id: int, should_return_image: bool = True):
         self.request_socket.send_multipart(
-            [b"REQUEST_IMAGE", str.encode(str(camera_id)), str.encode(str(should_return_image))]
+            [b"REQUEST_IMAGE", str.encode(str(camera_id)), str.encode(str(int(should_return_image)))]
         )
         [cob_x, cob_y, image_data_size, image_data] = self.request_socket.recv_multipart()
         image = None


### PR DESCRIPTION
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? How are your
commits organized? -->
Fixed issue where in Connector::ParseMessage, the stoi function was receiving after an image request either "True" or "False" instead of "1" or "0" for ShouldReturnImage which was causing Cielim to crash as of course this was invalid input for std::stoi. I fixed this by changing the test_harness to convert from bool to int before being encoded. Also updated test_demo to work with changes made to test_harness.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? If you didn't 
add or update any tests justify this choice. -->
Ran test with know working .bin file and correct output image was received.
