### PR TITLE
Add clang format to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,3 +18,8 @@ repos:
           args: ['--line-length=120', '--preview']
           language_version: python
           verbose: true
+-   repo: https://github.com/pocc/pre-commit-hooks
+    rev: v1.3.5
+    hooks:
+      -   id: clang-format
+          args: [-i, -style=file]


### PR DESCRIPTION
* **Tickets addressed:** 000
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This PR adds a clang-format hooks to pre-commit.

## Verification
Run locally with success.

## Documentation
Updated documentation to specify installing clang-format. 

## Future work
None
