### PR TITLE
add init requests by default in tests

### DIFF
--- a/Source/cielim-python/cielim/tests/test_camera_pose.py
+++ b/Source/cielim-python/cielim/tests/test_camera_pose.py
@@ -130,6 +130,7 @@ def test_camera_orientation(cielim_connection, scene_setup, test_name, mrp_rotat
     """
 
     connector = cielim_connection
+    connector.send_init_request()
     scene = scene_setup
 
     connector.send_frame(scene)

--- a/Source/cielim-python/cielim/tests/test_example.py
+++ b/Source/cielim-python/cielim/tests/test_example.py
@@ -42,6 +42,7 @@ def scene_setup():
 def test_example(cielim_connection, scene_setup):
 
     connector = cielim_connection
+    connector.send_init_request()
     scene_frame = scene.Scene()
     scene_frame.set_existing_message(scene_setup)
 

--- a/Source/cielim-python/cielim/tests/test_object_position.py
+++ b/Source/cielim-python/cielim/tests/test_object_position.py
@@ -58,6 +58,7 @@ def test_object_position(cielim_connection, scene_setup, test_name, shift):
     Parameters: Changing asteroid position in meters and verifying pixel shift.
     """
     connector = cielim_connection
+    connector.send_init_request()
     scene = scene_setup
     initial_x, initial_y, initial_z = scene.celestialBodies[0].position[:3]
 

--- a/Source/cielim-python/cielim/tests/test_object_size.py
+++ b/Source/cielim-python/cielim/tests/test_object_size.py
@@ -59,6 +59,7 @@ def test_asteroid_size(cielim_connection, scene_setup, test_name, shift):
     Parameters: Changing asteroid Z (closer/away) and slight X/Y shift, verifying pixel size.
     """
     connector = cielim_connection
+    connector.send_init_request()
     scene = scene_setup
     initial_position = scene.celestialBodies[0].position[:3]
 

--- a/Source/cielim-python/cielim/tests/test_request_center_of_brightness.py
+++ b/Source/cielim-python/cielim/tests/test_request_center_of_brightness.py
@@ -38,6 +38,7 @@ def scene_setup():
 
 def test_request_image_and_center_of_brightness(cielim_connection, scene_setup):
     connector = cielim_connection
+    connector.send_init_request()
     connector.send_frame(scene_setup)
 
     [image, center_of_brightness] = connector.request_image_for_camera_id(1, 1)

--- a/Source/cielim-python/examples/saved_monte_carlo_scenario.py
+++ b/Source/cielim-python/examples/saved_monte_carlo_scenario.py
@@ -4,6 +4,7 @@ import pickle
 
 import cv2
 import numpy as np
+import context
 from driver import *
 from launcher import *
 from variable_map import *

--- a/Source/cielim-python/examples/spice_scenario.py
+++ b/Source/cielim-python/examples/spice_scenario.py
@@ -19,8 +19,9 @@ def get_spice_data(filename):
     directory = filename.rsplit(".", 1)[0]
     meta_kernel = filename.rsplit("/")[-1].rsplit(".")[0]
     if not os.path.exists(directory):
+        print("Retrieving spice data")
         os.makedirs(directory)
-        with open(directory + "/" + meta_kernel + ".txt", "r") as file:
+        with open(directory + "/" + meta_kernel + ".txt", "w") as file:
             file.write("\\begindata\nPATH_VALUES = ( '" + directory + "' )\n")
             file.write("PATH_SYMBOLS = ( 'KERNELS' )\n")
             file.write("KERNELS_TO_LOAD=( \n\n")


### PR DESCRIPTION
* **Tickets addressed:** None- hot fix
* **Review:** By commit 
* **Merge strategy:** Merge (no squash)  

## Description
Fix pytest on develop. The issue was that some init requests were missing. 
Although not always necessary, it's a good idea to send an init request once per unit tests to ensure a clean slate before testing

## Verification
Tests pass

## Documentation
None

## Future work
None
