### PR TITLE
hotfix/cob-test-fix

### DIFF
--- a/Source/cielim-python/cielim/tests/test_request_center_of_brightness.py
+++ b/Source/cielim-python/cielim/tests/test_request_center_of_brightness.py
@@ -45,7 +45,7 @@ def test_request_image_and_center_of_brightness(cielim_connection, scene_setup):
     height, width, channels = image.shape
     np.testing.assert_allclose([4000, 3000], [width, height], rtol=0, atol=0, err_msg="Returned image not correct")
 
-    true_center_of_brightness = [1499.5, 1999.5]
+    true_center_of_brightness = [1999.5, 1499.5]
     np.testing.assert_allclose(
         center_of_brightness,
         true_center_of_brightness,
@@ -63,7 +63,7 @@ def test_request_only_center_of_brightness(cielim_connection, scene_setup):
 
     assert image == None
 
-    true_center_of_brightness = [1499.5, 1999.5]
+    true_center_of_brightness = [1999.5, 1499.5]
     np.testing.assert_allclose(
         center_of_brightness,
         true_center_of_brightness,


### PR DESCRIPTION
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? How are your
commits organized? --> Fixes the expected x and y cob values in the center of brightness python test. As can be seen in the test, the frame resolution is set to a size of [4000,3000], the spacecraft is spawned at [0,0,-1000000], and the sphere is spawned at [0,0,0]. Thus, the spacecraft is on the same x-z plane as the sphere and is looking directly towards it. Therefore, the expected center of brightness should be around [2000,1500], however it is currently [1500, 2000]. This PR fixes that.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? If you didn't 
add or update any tests justify this choice. --> Ran the center of brightness test using pytest. Reviewers should also verify using pytest.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and 
completeness? --> None.

## Future work
<!-- What next steps can we anticipate from here, if any? --> None.
