### PR TITLE
Disable TLS option in libzmq

### DIFF
--- a/Source/ThirdParty/OpenCV/OpenCV_build_win64.bat
+++ b/Source/ThirdParty/OpenCV/OpenCV_build_win64.bat
@@ -17,7 +17,7 @@ if exist "%opencv_lib_full_path%" (
 ) else (
 
     echo OpenCV will be built. Library %opencv_lib_full_path% not found.
-    
+
     @REM Make sure we're in the OpenCV folder
     cd /d "%~1"
 

--- a/Source/ThirdParty/OpenCV/OpenCV_build_win64.bat
+++ b/Source/ThirdParty/OpenCV/OpenCV_build_win64.bat
@@ -35,14 +35,14 @@ if exist "%opencv_lib_full_path%" (
         -D CMAKE_BUILD_TYPE=Release ^
         -D CMAKE_INSTALL_PREFIX=.. ^
         -D INSTALL_CREATE_DISTRIB=ON ^
-        -D OPENCV_EXTRA_MODULES_PATH=../../opencv_contrib/modules \
+        -D OPENCV_EXTRA_MODULES_PATH=../../opencv_contrib/modules ^
         -D WITH_CUDA:BOOL=OFF ^
         -D WITH_FFMPEG=OFF ^
         -D WITH_GSTREAMER:BOOL=OFF ^
         -D WITH_IPP=OFF ^
         -D WITH_OPENEXR:BOOL=OFF ^
         -D WITH_TESSERACT:BOOL=OFF ^
-        -D WITH_VTK:BOOL=OFF 
+        -D WITH_VTK:BOOL=OFF
     cmake --build . --parallel 8 --config Release
 
     @REM You need to install here or else headers won't all be in the same place

--- a/Source/ThirdParty/ProtobufLibrary/ProtobufLibrary_build.sh
+++ b/Source/ThirdParty/ProtobufLibrary/ProtobufLibrary_build.sh
@@ -24,7 +24,7 @@ else
 
     # Apply patch for v3.17.1 which was fixed at the below URL
     # but didn't get in to protobufs until 3.20.0. Unfortunately,
-    # the most recent version we can used is tied to BSK's 
+    # the most recent version we can used is tied to BSK's
     # currently or 3.17.1
     git apply ../Protobuf_patch1.patch
     git apply ../Protobuf_patch2.patch
@@ -32,8 +32,8 @@ else
     # Link to fix:
     # https://github.com/protocolbuffers/protobuf/commit/ef1c9fd9077440acacf4fec112153dda4a2c9d44#diff-d35d85d6ef5be92bdbaa901ca9155566f5d7dc2e4fbf5e4ae6d111a615169959
 
-    # AutoMake Build 
-    echo "Building ptotobuf..."
+    # AutoMake Build
+    echo "Building protobuf..."
     ./autogen.sh
     ./configure
     make -j8

--- a/Source/ThirdParty/ZMQ/ZMQ_build.sh
+++ b/Source/ThirdParty/ZMQ/ZMQ_build.sh
@@ -21,7 +21,7 @@ else
 
     # CMake Build
     echo "Building libzmq..."
-    mkdir build
+    mkdir -p build
     cd build
     cmake .. \
         -DCMAKE_BUILD_TYPE=Release \

--- a/Source/ThirdParty/ZMQ/ZMQ_build.sh
+++ b/Source/ThirdParty/ZMQ/ZMQ_build.sh
@@ -23,8 +23,10 @@ else
     echo "Building libzmq..."
     mkdir build
     cd build
-    cmake .. -DWITH_TLS="NO"
-    make -j4
+    cmake .. \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DWITH_TLS="NO"
+    cmake --build . --parallel 8 --config Release
 
     cd ../..
 

--- a/Source/ThirdParty/ZMQ/ZMQ_build.sh
+++ b/Source/ThirdParty/ZMQ/ZMQ_build.sh
@@ -9,7 +9,7 @@ set zmq_lib_full_path = ${1}${zmq_lib_path}
 echo "zmq_lib_full_path: ${zmq_lib_full_path}"
 
 if ( -f $zmq_lib_full_path ) then
-  echo "ZMQ will not be rebuilt. Library ${zmq_lib_full_path} exists."
+    echo "ZMQ will not be rebuilt. Library ${zmq_lib_full_path} exists."
 else
     echo "ZMQ will be built. Library ${zmq_lib_full_path} not found."
 
@@ -19,7 +19,7 @@ else
     cd libzmq
     git submodule update --init --recursive
 
-    # CMake Build 
+    # CMake Build
     echo "Building libzmq..."
     mkdir build
     cd build

--- a/Source/ThirdParty/ZMQ/ZMQ_build.sh
+++ b/Source/ThirdParty/ZMQ/ZMQ_build.sh
@@ -28,15 +28,8 @@ else
 
     cd ../..
 
-    # Do all of that for cppZMQ
+    # Check cppZMQ
     cd cppzmq
     git submodule update --init --recursive
 
-    # CMake Build 
-    echo "Building cppzmq..."
-    mkdir build
-    cd build
-    cmake .. -DCMAKE_INSTALL_PREFIX="../../libzmq"
-    make -j4
-    
 endif

--- a/Source/ThirdParty/ZMQ/ZMQ_build.sh
+++ b/Source/ThirdParty/ZMQ/ZMQ_build.sh
@@ -23,7 +23,7 @@ else
     echo "Building libzmq..."
     mkdir build
     cd build
-    cmake ..
+    cmake .. -DWITH_TLS="NO"
     make -j4
 
     cd ../..

--- a/Source/ThirdParty/ZMQ/ZMQ_build_win64.bat
+++ b/Source/ThirdParty/ZMQ/ZMQ_build_win64.bat
@@ -26,7 +26,9 @@ if exist "%zmq_lib_full_path%" (
 
     @REM CMake Build
     echo Building libzmq...
-    mkdir build
+    IF NOT EXIST "build" (
+        mkdir build
+    )
     cd build
     cmake .. -G "Visual Studio 17 2022" -A x64 ^
         -DCMAKE_BUILD_TYPE=Release ^

--- a/Source/ThirdParty/ZMQ/ZMQ_build_win64.bat
+++ b/Source/ThirdParty/ZMQ/ZMQ_build_win64.bat
@@ -28,7 +28,9 @@ if exist "%zmq_lib_full_path%" (
     echo Building libzmq...
     mkdir build
     cd build
-    cmake .. -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release -DWITH_TLS="NO"
+    cmake .. -G "Visual Studio 17 2022" -A x64 ^
+        -DCMAKE_BUILD_TYPE=Release ^
+        -DWITH_TLS="NO"
     cmake --build . --parallel 8 --config Release
 
     cd "..\.."

--- a/Source/ThirdParty/ZMQ/ZMQ_build_win64.bat
+++ b/Source/ThirdParty/ZMQ/ZMQ_build_win64.bat
@@ -28,7 +28,7 @@ if exist "%zmq_lib_full_path%" (
     echo Building libzmq...
     mkdir build
     cd build
-    cmake .. -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release
+    cmake .. -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release -DWITH_TLS="NO"
     cmake --build . --parallel 8 --config Release
 
     cd "..\.."

--- a/Source/ThirdParty/ZMQ/ZMQ_build_win64.bat
+++ b/Source/ThirdParty/ZMQ/ZMQ_build_win64.bat
@@ -33,14 +33,7 @@ if exist "%zmq_lib_full_path%" (
 
     cd "..\.."
 
-    @REM Do all of that for cppZMQ
+    @REM Check cppZMQ
     cd cppzmq
     git submodule update --init --recursive
-
-    @REM CMake Build 
-    echo Building cppzmq...
-    mkdir build
-    cd build
-    cmake .. -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="../../libzmq"
-    cmake --build . --parallel 8 --config Release
 )

--- a/Source/ThirdParty/ZMQ/ZMQ_build_win64.bat
+++ b/Source/ThirdParty/ZMQ/ZMQ_build_win64.bat
@@ -24,7 +24,7 @@ if exist "%zmq_lib_full_path%" (
     cd libzmq
     git submodule update --init --recursive
 
-    @REM CMake Build 
+    @REM CMake Build
     echo Building libzmq...
     mkdir build
     cd build

--- a/cielim.uproject
+++ b/cielim.uproject
@@ -130,9 +130,9 @@
 	{
 		"Mac": [
 			"export PATH=/opt/homebrew/bin:$PATH",
-			"tcsh $(ProjectDir)/Source/ThirdParty/OpenCV/OpenCV_build.sh \"$(ProjectDir)/Source/ThirdParty/OpenCV/\" ",
-			"tcsh $(ProjectDir)/Source/ThirdParty/ProtobufLibrary/ProtobufLibrary_build.sh \"$(ProjectDir)/Source/ThirdParty/ProtobufLibrary/\" ",
-			"tcsh $(ProjectDir)/Source/ThirdParty/ZMQ/ZMQ_build.sh \"$(ProjectDir)/Source/ThirdParty/ZMQ/\" "
+			"tcsh -ef $(ProjectDir)/Source/ThirdParty/OpenCV/OpenCV_build.sh \"$(ProjectDir)/Source/ThirdParty/OpenCV/\" ",
+			"tcsh -ef $(ProjectDir)/Source/ThirdParty/ProtobufLibrary/ProtobufLibrary_build.sh \"$(ProjectDir)/Source/ThirdParty/ProtobufLibrary/\" ",
+			"tcsh -ef $(ProjectDir)/Source/ThirdParty/ZMQ/ZMQ_build.sh \"$(ProjectDir)/Source/ThirdParty/ZMQ/\" "
 		],
 		"Win64": [
 			"call $(ProjectDir)\\Source\\ThirdParty\\OpenCV\\OpenCV_build_win64.bat \"$(ProjectDir)\\Source\\ThirdParty\\OpenCV\\\" ",


### PR DESCRIPTION
* **Tickets addressed:** 1614
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
The libzmq build was failing at the linker stage unable to find specific gnutils symbols. The project doesn't currently use TLS in its messaging as so it make sense to turn off the build portion for that feature. Separately, we can continue to investigate that part of the build in the case that we decide to integrate secure messaging (which has been proposed).

The remaining commits in this PR, turn off the build of the CPPZMQ tests (given we don't run them), and then edits the unix ZMQ build scripts to match the windows ZMQ build script.

## Verification
Build successful with `python build.py`. All tests ran and pass. 

## Documentation
NA

## Future work
We will look into this linker issue closer to any work that implements secure messaging. 
